### PR TITLE
Move javadoc-plugin execution to 'apache-release' profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,29 +222,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${javadoc.plugin.version}</version>
-				<configuration>
-					<doclint>none</doclint>
-					<source>${java.version}</source>
-					<sourcepath>src/main/java</sourcepath>
-				</configuration>
-				<executions>
-					<execution>
-						<id>create-javadoc-jar</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<phase>package</phase>
-						<configuration>
-							<show>public</show>
-							<quiet>false</quiet>
-							<use>false</use> <!-- Speeds up the build of the javadocs -->
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 
@@ -253,6 +230,29 @@
 		<id>apache-release</id>
 		<build>
 			<plugins>
+				<plugin>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>${javadoc.plugin.version}</version>
+					<configuration>
+						<doclint>none</doclint>
+						<source>${java.version}</source>
+						<sourcepath>src/main/java</sourcepath>
+					</configuration>
+					<executions>
+						<execution>
+							<id>create-javadoc-jar</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+							<phase>package</phase>
+							<configuration>
+								<show>public</show>
+								<quiet>false</quiet>
+								<use>false</use> <!-- Speeds up the build of the javadocs -->
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.rat</groupId>
 					<artifactId>apache-rat-plugin</artifactId>


### PR DESCRIPTION
Change
-
- adjust build for 'non-Java JARs' bundling flavor
- clears _creating fake javadoc directory to prevent repeated invocations_ warnings and effort for non-release builds