### PR TITLE
OPENNLP-1749: Release pre-trained OpenNLP Models 1.3.0

### DIFF
--- a/opennlp-models-langdetect/pom.xml
+++ b/opennlp-models-langdetect/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.opennlp</groupId>
     <artifactId>opennlp-models</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>opennlp-models-langdetect</artifactId>

--- a/opennlp-models-langdetect/pom.xml
+++ b/opennlp-models-langdetect/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.opennlp</groupId>
     <artifactId>opennlp-models</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>opennlp-models-langdetect</artifactId>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-af/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Afrikaans</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-af/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Afrikaans</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-bg/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Bulgarian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-bg/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Bulgarian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ca/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Catalan</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ca/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Catalan</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-cs/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Czech</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-cs/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Czech</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-da/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Danish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-da/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Danish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-de/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: German</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-de/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: German</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-el/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Greek</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-el/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Greek</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-en/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: English</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-en/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: English</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-es/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-es/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Spanish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-es/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-es/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Spanish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-et/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-et/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Estonian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-et/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-et/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Estonian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-eu/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Basque</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-eu/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Basque</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fa/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Persian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fa/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Persian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fi/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fi/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Finnish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fi/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fi/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Finnish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: French</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: French</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ga/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Irish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ga/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Irish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Croatian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Croatian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hy/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Armenian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hy/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Armenian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-id/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Indonesian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-id/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Indonesian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-is/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Icelandic</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-is/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Icelandic</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-it/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Italian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-it/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Italian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ka/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Georgian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ka/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Georgian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-kk/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Kazakh</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-kk/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Kazakh</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ko/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Korean</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ko/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Korean</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-lv/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-lv/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Latvian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-lv/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-lv/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Latvian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-nl/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Dutch</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-nl/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Dutch</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-no/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-no/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Norwegian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-no/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-no/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Norwegian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pl/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Polish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pl/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Polish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pt/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pt/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Portuguese</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pt/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-pt/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Portuguese</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ro/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ro/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Romanian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ro/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ro/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Romanian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ru/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ru/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Russian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ru/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-ru/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Russian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sk/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Slovak</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sk/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Slovak</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sl/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Slovenian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sl/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Slovenian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Serbian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Serbian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sv/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sv/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Swedish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sv/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-sv/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Swedish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-tr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-tr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Turkish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-tr/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-tr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Turkish</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-uk/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-uk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Ukrainian</name>

--- a/opennlp-models-lemmatizer/opennlp-models-lemmatizer-uk/pom.xml
+++ b/opennlp-models-lemmatizer/opennlp-models-lemmatizer-uk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-lemmatizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Lemmatizer :: Ukrainian</name>

--- a/opennlp-models-lemmatizer/pom.xml
+++ b/opennlp-models-lemmatizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.opennlp</groupId>
     <artifactId>opennlp-models</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>opennlp-models-lemmatizer</artifactId>

--- a/opennlp-models-lemmatizer/pom.xml
+++ b/opennlp-models-lemmatizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.opennlp</groupId>
     <artifactId>opennlp-models</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>opennlp-models-lemmatizer</artifactId>

--- a/opennlp-models-pos/opennlp-models-pos-af/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Afrikaans</name>

--- a/opennlp-models-pos/opennlp-models-pos-af/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Afrikaans</name>

--- a/opennlp-models-pos/opennlp-models-pos-bg/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Bulgarian</name>

--- a/opennlp-models-pos/opennlp-models-pos-bg/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Bulgarian</name>

--- a/opennlp-models-pos/opennlp-models-pos-ca/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Catalan</name>

--- a/opennlp-models-pos/opennlp-models-pos-ca/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Catalan</name>

--- a/opennlp-models-pos/opennlp-models-pos-cs/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Czech</name>

--- a/opennlp-models-pos/opennlp-models-pos-cs/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Czech</name>

--- a/opennlp-models-pos/opennlp-models-pos-da/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Danish</name>

--- a/opennlp-models-pos/opennlp-models-pos-da/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Danish</name>

--- a/opennlp-models-pos/opennlp-models-pos-de/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: German</name>

--- a/opennlp-models-pos/opennlp-models-pos-de/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: German</name>

--- a/opennlp-models-pos/opennlp-models-pos-el/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Greek</name>

--- a/opennlp-models-pos/opennlp-models-pos-el/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Greek</name>

--- a/opennlp-models-pos/opennlp-models-pos-en/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: English</name>

--- a/opennlp-models-pos/opennlp-models-pos-en/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: English</name>

--- a/opennlp-models-pos/opennlp-models-pos-es/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-es/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Spanish</name>  
   <artifactId>opennlp-models-pos-es</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-es/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-es/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Spanish</name>  
   <artifactId>opennlp-models-pos-es</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-et/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-et/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Estonian</name>  
   <artifactId>opennlp-models-pos-et</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-et/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-et/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Estonian</name>  
   <artifactId>opennlp-models-pos-et</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-eu/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Basque</name>

--- a/opennlp-models-pos/opennlp-models-pos-eu/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Basque</name>

--- a/opennlp-models-pos/opennlp-models-pos-fa/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Persian</name>

--- a/opennlp-models-pos/opennlp-models-pos-fa/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Persian</name>

--- a/opennlp-models-pos/opennlp-models-pos-fi/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-fi/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Finnish</name>  
   <artifactId>opennlp-models-pos-fi</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-fi/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-fi/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Finnish</name>  
   <artifactId>opennlp-models-pos-fi</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-fr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: French</name>

--- a/opennlp-models-pos/opennlp-models-pos-fr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: French</name>

--- a/opennlp-models-pos/opennlp-models-pos-ga/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Irish</name>

--- a/opennlp-models-pos/opennlp-models-pos-ga/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Irish</name>

--- a/opennlp-models-pos/opennlp-models-pos-hr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Croatian</name>

--- a/opennlp-models-pos/opennlp-models-pos-hr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Croatian</name>

--- a/opennlp-models-pos/opennlp-models-pos-hy/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Armenian</name>

--- a/opennlp-models-pos/opennlp-models-pos-hy/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Armenian</name>

--- a/opennlp-models-pos/opennlp-models-pos-id/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Indonesian</name>

--- a/opennlp-models-pos/opennlp-models-pos-id/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Indonesian</name>

--- a/opennlp-models-pos/opennlp-models-pos-is/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Icelandic</name>

--- a/opennlp-models-pos/opennlp-models-pos-is/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Icelandic</name>

--- a/opennlp-models-pos/opennlp-models-pos-it/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Italian</name>

--- a/opennlp-models-pos/opennlp-models-pos-it/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Italian</name>

--- a/opennlp-models-pos/opennlp-models-pos-ka/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Georgian</name>

--- a/opennlp-models-pos/opennlp-models-pos-ka/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Georgian</name>

--- a/opennlp-models-pos/opennlp-models-pos-kk/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Kazakh</name>

--- a/opennlp-models-pos/opennlp-models-pos-kk/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Kazakh</name>

--- a/opennlp-models-pos/opennlp-models-pos-ko/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Korean</name>

--- a/opennlp-models-pos/opennlp-models-pos-ko/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Korean</name>

--- a/opennlp-models-pos/opennlp-models-pos-lv/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-lv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Latvian</name>  
   <artifactId>opennlp-models-pos-lv</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-lv/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-lv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Latvian</name>  
   <artifactId>opennlp-models-pos-lv</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-nl/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Dutch</name>

--- a/opennlp-models-pos/opennlp-models-pos-nl/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Dutch</name>

--- a/opennlp-models-pos/opennlp-models-pos-no/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-no/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Norwegian</name>  
   <artifactId>opennlp-models-pos-no</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-no/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-no/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Norwegian</name>  
   <artifactId>opennlp-models-pos-no</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-pl/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-pl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Polish</name>  
   <artifactId>opennlp-models-pos-pl</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-pl/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-pl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Polish</name>  
   <artifactId>opennlp-models-pos-pl</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-pt/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-pt/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Portuguese</name>  
   <artifactId>opennlp-models-pos-pt</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-pt/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-pt/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Portuguese</name>  
   <artifactId>opennlp-models-pos-pt</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-ro/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ro/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Romanian</name>  
   <artifactId>opennlp-models-pos-ro</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-ro/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ro/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Romanian</name>  
   <artifactId>opennlp-models-pos-ro</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-ru/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ru/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Russian</name>  
   <artifactId>opennlp-models-pos-ru</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-ru/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-ru/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Russian</name>  
   <artifactId>opennlp-models-pos-ru</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sk/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Slovak</name>  
   <artifactId>opennlp-models-pos-sk</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sk/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Slovak</name>  
   <artifactId>opennlp-models-pos-sk</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sl/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Slovenian</name>  
   <artifactId>opennlp-models-pos-sl</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sl/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Slovenian</name>  
   <artifactId>opennlp-models-pos-sl</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sr/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Serbian</name>  
   <artifactId>opennlp-models-pos-sr</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sr/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Serbian</name>  
   <artifactId>opennlp-models-pos-sr</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sv/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Swedish</name>  
   <artifactId>opennlp-models-pos-sv</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-sv/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-sv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Swedish</name>  
   <artifactId>opennlp-models-pos-sv</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-tr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-tr/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Turkish</name>

--- a/opennlp-models-pos/opennlp-models-pos-tr/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-tr/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-pos</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <name>Apache OpenNLP Models :: Part-Of-Speech :: Turkish</name>

--- a/opennlp-models-pos/opennlp-models-pos-uk/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-uk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Ukrainian</name>  
   <artifactId>opennlp-models-pos-uk</artifactId>  

--- a/opennlp-models-pos/opennlp-models-pos-uk/pom.xml
+++ b/opennlp-models-pos/opennlp-models-pos-uk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-pos</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Part-Of-Speech :: Ukrainian</name>  
   <artifactId>opennlp-models-pos-uk</artifactId>  

--- a/opennlp-models-pos/pom.xml
+++ b/opennlp-models-pos/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-pos</artifactId>

--- a/opennlp-models-pos/pom.xml
+++ b/opennlp-models-pos/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-pos</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-af/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-af</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-af/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-af</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-bg/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-bg</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-bg/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-bg</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ca/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ca</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ca/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ca</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-cs/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-cs</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-cs/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-cs</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-da/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-da</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-da/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-da</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-de/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-de</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-de/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-de</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-el/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-el</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-el/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-el</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-en/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-en</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-en/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-en</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-es/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-es/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Spanish</name>  
   <artifactId>opennlp-models-sentdetect-es</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-es/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-es/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Spanish</name>  
   <artifactId>opennlp-models-sentdetect-es</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-et/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-et/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Estonian</name>  
   <artifactId>opennlp-models-sentdetect-et</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-et/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-et/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Estonian</name>  
   <artifactId>opennlp-models-sentdetect-et</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-eu/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-eu</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-eu/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-eu</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-fa/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-fa</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-fa/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-fa</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-fi/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-fi/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Finnish</name>  
   <artifactId>opennlp-models-sentdetect-fi</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-fi/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-fi/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Finnish</name>  
   <artifactId>opennlp-models-sentdetect-fi</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-fr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-fr</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-fr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-fr</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ga/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ga</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ga/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ga</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-hr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-hr</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-hr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-hr</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-hy/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-hy</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-hy/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-hy</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-id/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-id</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-id/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-id</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-is/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-is</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-is/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-is</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-it/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-it</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-it/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-it</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ka/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ka</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ka/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ka</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-kk/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-kk</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-kk/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-kk</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ko/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ko</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ko/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-ko</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-lv/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-lv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Latvian</name>  
   <artifactId>opennlp-models-sentdetect-lv</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-lv/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-lv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Latvian</name>  
   <artifactId>opennlp-models-sentdetect-lv</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-nl/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-nl</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-nl/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-nl</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-no/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-no/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Norwegian</name>  
   <artifactId>opennlp-models-sentdetect-no</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-no/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-no/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Norwegian</name>  
   <artifactId>opennlp-models-sentdetect-no</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-pl/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-pl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Polish</name>  
   <artifactId>opennlp-models-sentdetect-pl</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-pl/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-pl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Polish</name>  
   <artifactId>opennlp-models-sentdetect-pl</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-pt/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-pt/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Portuguese</name>  
   <artifactId>opennlp-models-sentdetect-pt</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-pt/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-pt/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Portuguese</name>  
   <artifactId>opennlp-models-sentdetect-pt</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ro/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ro/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Romanian</name>  
   <artifactId>opennlp-models-sentdetect-ro</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ro/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ro/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Romanian</name>  
   <artifactId>opennlp-models-sentdetect-ro</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ru/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ru/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Russian</name>  
   <artifactId>opennlp-models-sentdetect-ru</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-ru/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-ru/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Russian</name>  
   <artifactId>opennlp-models-sentdetect-ru</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sk/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Slovak</name>  
   <artifactId>opennlp-models-sentdetect-sk</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sk/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Slovak</name>  
   <artifactId>opennlp-models-sentdetect-sk</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sl/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Slovenian</name>  
   <artifactId>opennlp-models-sentdetect-sl</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sl/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Slovenian</name>  
   <artifactId>opennlp-models-sentdetect-sl</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sr/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Serbian</name>  
   <artifactId>opennlp-models-sentdetect-sr</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sr/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Serbian</name>  
   <artifactId>opennlp-models-sentdetect-sr</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sv/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Swedish</name>  
   <artifactId>opennlp-models-sentdetect-sv</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-sv/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-sv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Swedish</name>  
   <artifactId>opennlp-models-sentdetect-sv</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-tr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-tr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-tr</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-tr/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-tr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-sentdetect</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect-tr</artifactId>

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-uk/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-uk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Ukrainian</name>  
   <artifactId>opennlp-models-sentdetect-uk</artifactId>  

--- a/opennlp-models-sentdetect/opennlp-models-sentdetect-uk/pom.xml
+++ b/opennlp-models-sentdetect/opennlp-models-sentdetect-uk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-sentdetect</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Sent-Detect :: Ukrainian</name>  
   <artifactId>opennlp-models-sentdetect-uk</artifactId>  

--- a/opennlp-models-sentdetect/pom.xml
+++ b/opennlp-models-sentdetect/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect</artifactId>

--- a/opennlp-models-sentdetect/pom.xml
+++ b/opennlp-models-sentdetect/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-sentdetect</artifactId>

--- a/opennlp-models-test/pom.xml
+++ b/opennlp-models-test/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-test</artifactId>

--- a/opennlp-models-test/pom.xml
+++ b/opennlp-models-test/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-test</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-af/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-af</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-af/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-af/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-af</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-bg/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-bg</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-bg/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-bg/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-bg</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ca/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ca</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ca/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ca/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ca</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-cs/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-cs</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-cs/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-cs/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-cs</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-da/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-da</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-da/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-da/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-da</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-de/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-de</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-de/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-de/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-de</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-el/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-el</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-el/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-el/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-el</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-en/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-en</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-en/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-en/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-en</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-es/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-es/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Spanish</name>  
   <artifactId>opennlp-models-tokenizer-es</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-es/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-es/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Spanish</name>  
   <artifactId>opennlp-models-tokenizer-es</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-et/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-et/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Estonian</name>  
   <artifactId>opennlp-models-tokenizer-et</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-et/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-et/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Estonian</name>  
   <artifactId>opennlp-models-tokenizer-et</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-eu/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-eu</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-eu/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-eu/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-eu</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-fa/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-fa</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-fa/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-fa/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-fa</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-fi/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-fi/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Finnish</name>  
   <artifactId>opennlp-models-tokenizer-fi</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-fi/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-fi/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Finnish</name>  
   <artifactId>opennlp-models-tokenizer-fi</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-fr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-fr</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-fr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-fr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-fr</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ga/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ga</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ga/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ga/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ga</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-hr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-hr</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-hr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-hr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-hr</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-hy/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-hy</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-hy/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-hy/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-hy</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-id/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-id</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-id/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-id/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-id</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-is/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-is</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-is/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-is/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-is</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-it/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-it</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-it/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-it/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-it</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ka/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ka</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ka/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ka/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ka</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-kk/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-kk</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-kk/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-kk/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-kk</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ko/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ko</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ko/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ko/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-ko</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-lv/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-lv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Latvian</name>  
   <artifactId>opennlp-models-tokenizer-lv</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-lv/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-lv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Latvian</name>  
   <artifactId>opennlp-models-tokenizer-lv</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-nl/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-nl</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-nl/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-nl/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-nl</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-no/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-no/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Norwegian</name>  
   <artifactId>opennlp-models-tokenizer-no</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-no/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-no/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Norwegian</name>  
   <artifactId>opennlp-models-tokenizer-no</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-pl/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-pl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Polish</name>  
   <artifactId>opennlp-models-tokenizer-pl</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-pl/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-pl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Polish</name>  
   <artifactId>opennlp-models-tokenizer-pl</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-pt/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-pt/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Portuguese</name>  
   <artifactId>opennlp-models-tokenizer-pt</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-pt/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-pt/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Portuguese</name>  
   <artifactId>opennlp-models-tokenizer-pt</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ro/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ro/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Romanian</name>  
   <artifactId>opennlp-models-tokenizer-ro</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ro/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ro/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Romanian</name>  
   <artifactId>opennlp-models-tokenizer-ro</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ru/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ru/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Russian</name>  
   <artifactId>opennlp-models-tokenizer-ru</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-ru/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-ru/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Russian</name>  
   <artifactId>opennlp-models-tokenizer-ru</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sk/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Slovak</name>  
   <artifactId>opennlp-models-tokenizer-sk</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sk/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Slovak</name>  
   <artifactId>opennlp-models-tokenizer-sk</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sl/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Slovenian</name>  
   <artifactId>opennlp-models-tokenizer-sl</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sl/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sl/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Slovenian</name>  
   <artifactId>opennlp-models-tokenizer-sl</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sr/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Serbian</name>  
   <artifactId>opennlp-models-tokenizer-sr</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sr/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Serbian</name>  
   <artifactId>opennlp-models-tokenizer-sr</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sv/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Swedish</name>  
   <artifactId>opennlp-models-tokenizer-sv</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-sv/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-sv/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Swedish</name>  
   <artifactId>opennlp-models-tokenizer-sv</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-tr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-tr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-tr</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-tr/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-tr/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-tokenizer</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer-tr</artifactId>

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-uk/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-uk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Ukrainian</name>  
   <artifactId>opennlp-models-tokenizer-uk</artifactId>  

--- a/opennlp-models-tokenizer/opennlp-models-tokenizer-uk/pom.xml
+++ b/opennlp-models-tokenizer/opennlp-models-tokenizer-uk/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent> 
     <groupId>org.apache.opennlp</groupId>  
     <artifactId>opennlp-models-tokenizer</artifactId>  
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>  
   <name>Apache OpenNLP Models :: Tokenizer :: Ukrainian</name>  
   <artifactId>opennlp-models-tokenizer-uk</artifactId>  

--- a/opennlp-models-tokenizer/pom.xml
+++ b/opennlp-models-tokenizer/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer</artifactId>

--- a/opennlp-models-tokenizer/pom.xml
+++ b/opennlp-models-tokenizer/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-tokenizer</artifactId>

--- a/opennlp-models-training/opennlp-models-training-ud/pom.xml
+++ b/opennlp-models-training/opennlp-models-training-ud/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-training</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>opennlp-models-training-ud</artifactId>

--- a/opennlp-models-training/opennlp-models-training-ud/pom.xml
+++ b/opennlp-models-training/opennlp-models-training-ud/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models-training</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opennlp-models-training-ud</artifactId>

--- a/opennlp-models-training/pom.xml
+++ b/opennlp-models-training/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/opennlp-models-training/pom.xml
+++ b/opennlp-models-training/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.opennlp</groupId>
         <artifactId>opennlp-models</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
 	<groupId>org.apache.opennlp</groupId>
 	<artifactId>opennlp-models</artifactId>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>1.3.0</version>
 	<packaging>pom</packaging>
 
 	<name>Apache OpenNLP Models</name>
@@ -40,7 +40,7 @@
 		<connection>scm:git:https://github.com/apache/opennlp-models.git</connection>
 		<developerConnection>scm:git:git@github.com:apache/opennlp-models.git</developerConnection>
 		<url>https://github.com/apache/opennlp-models.git</url>
-	    <tag>HEAD</tag>
+	    <tag>opennlp-models-1.3.0</tag>
   </scm>
 
 	<repositories>
@@ -105,7 +105,7 @@
 		<sf.dist.base>https://opennlp.sourceforge.net/models-1.5/</sf.dist.base>
 
 		<!-- set a fixed value here to enable reproducible builds -->
-		<project.build.outputTimestamp>2024-11-25T11:34:11Z</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2025-06-18T13:00:35Z</project.build.outputTimestamp>
 
 		<!-- maven plugin versions -->
 		<download.plugin.version>1.13.0</download.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
 	<groupId>org.apache.opennlp</groupId>
 	<artifactId>opennlp-models</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Apache OpenNLP Models</name>
@@ -105,7 +105,7 @@
 		<sf.dist.base>https://opennlp.sourceforge.net/models-1.5/</sf.dist.base>
 
 		<!-- set a fixed value here to enable reproducible builds -->
-		<project.build.outputTimestamp>2025-06-18T13:00:35Z</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2025-06-18T13:19:09Z</project.build.outputTimestamp>
 
 		<!-- maven plugin versions -->
 		<download.plugin.version>1.13.0</download.plugin.version>


### PR DESCRIPTION
Once the vote: https://lists.apache.org/thread/y0h23oczsnx4jsf03gvtgydxr7z2kmm4 has passed.